### PR TITLE
updated AMI IDs to Dragen v3.6.3 and added eu-west-2 and eu-central-1 regions

### DIFF
--- a/ci/config.yml
+++ b/ci/config.yml
@@ -4,6 +4,8 @@ global:
   qsname: quickstart-illumina-dragen
   regions:
     - eu-west-1
+    - eu-west-2
+    - eu-central-1
     - us-east-1
     - us-west-2
   reporting: true
@@ -16,6 +18,8 @@ tests:
       - us-east-1
       - us-west-2
       - eu-west-1
+      - eu-west-2
+      - eu-central-1
  # quickstart-illumina-dragent2:
  #   parameter_input: batch-params.t2.json
  #   template_file: dragen-master.template
@@ -23,3 +27,5 @@ tests:
  #     - us-east-1
  #     - us-west-2
  #     - eu-west-1
+ #     - eu-west-2
+ #     - eu-central-1

--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -4,6 +4,8 @@ global:
   qsname: quickstart-illumina-dragen
   regions:
     - eu-west-1
+    - eu-west-2
+    - eu-central-1
     - us-east-1
     - us-west-2
   reporting: true
@@ -16,6 +18,8 @@ tests:
       - us-east-1
       - us-west-2
       - eu-west-1
+      - eu-west-2
+      - eu-central-1
  # quickstart-illumina-dragent2:
  #   parameter_input: batch-params.t2.json
  #   template_file: dragen-master.template
@@ -23,3 +27,5 @@ tests:
  #     - us-east-1
  #     - us-west-2
  #     - eu-west-1
+ #     - eu-west-2
+ #     - eu-central-1

--- a/templates/dragen.yaml
+++ b/templates/dragen.yaml
@@ -68,11 +68,16 @@ Mappings:
     AMI:
       DRAGEN: dragen-completesuite-*
     us-east-1:
-      DRAGEN: ami-0cafb92d020f85994
+      DRAGEN: ami-0f6d303d50f74e4c5
     us-west-2:
-      DRAGEN: ami-06ef6a3ed477d2504
+      DRAGEN: ami-0207165c3b40514db
     eu-west-1:
-      DRAGEN: ami-0db22398af10a82b3
+      DRAGEN: ami-015ebca287021523c
+    eu-west-2:
+      DRAGEN: ami-0ecdc8895181c7ac7
+    eu-central-1:
+      DRAGEN: ami-0b4d60fefb3b8535c
+
 
 Parameters:
   InstanceType:
@@ -181,6 +186,8 @@ Rules:
         - - us-east-1
           - us-west-2
           - eu-west-1
+          - eu-west-2
+          - eu-central-1
         - !Ref AWS::Region
       AssertDescription: This Quick Start utilizes DRAGEN Marketplace AMI which is only available
         in the US East (N. Virginia), US West (Oregon), EU (Ireland) regions. Please launch the stack in one of these


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Minor update to quickstart for the latest version of the DRAGEN Complete Suite Software (v3.6.3) https://aws.amazon.com/marketplace/pp/B07CZ3F5HY


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
